### PR TITLE
Add Python 3.6, drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+source = zope.tales
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError
+    raise unittest.Skip

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bin
 build
 develop-eggs
 parts
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,23 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
-    - pypy
-    - pypy3
+    - 3.6
+    # Force a newer PyPy on the old 'precise' CI image
+    # in order to install 'cryptography' needed for coveralls
+    # After September 2017 this should be the default and the version
+    # pin can be removed.
+    - pypy-5.6.0
+    - pypy3.5-5.8.0
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - python setup.py -q test -q
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,22 +1,24 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.2.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6 and 3.2.
+- Drop support for Python 2.6, 3.2 and 3.3.
 
+- Drop support for ``python setup.py test``.
 
 4.1.1 (2015-06-06)
-------------------
+==================
 
 - Add support for Python 3.2 and PyPy3.
 
 
 4.1.0 (2014-12-29)
-------------------
+==================
 
 .. note::
 
@@ -29,19 +31,19 @@ Changes
 
 
 4.0.2 (2013-11-12)
-------------------
+==================
 
 - Add missing ``six`` dependency
 
 
 4.0.1 (2013-02-22)
-------------------
+==================
 
 - Fix a previously untested Python 3.3 compatibility problem.
 
 
 4.0.0 (2013-02-14)
-------------------
+==================
 
 - Remove hard dependency on ``zope.tal``, which was already conditionalized
   but required via ``setup.py``.
@@ -57,26 +59,26 @@ Changes
 
 
 3.5.2 (2012-05-23)
-------------------
+==================
 
 - Subexpressions of a 'string:' expression can be only path expressions.
   https://bugs.launchpad.net/zope.tales/+bug/1002242
 
 
 3.5.1 (2010-04-30)
-------------------
+==================
 
 - Remove use of ``zope.testing.doctestunit`` in favor of stdlib's 'doctest.
 
 
 3.5.0 (2010-01-01)
-------------------
+==================
 
 - Port the lazy expression from ``Products.PageTemplates``.
 
 
 3.4.0 (2007-10-03)
-------------------
+==================
 
 - Update package setup.
 
@@ -84,7 +86,7 @@ Changes
 
 
 3.2.0 (2006-01-05)
-------------------
+==================
 
 - Corresponds to the verison of the zope.tales package shipped as part of
   the Zope 3.2.0 release.
@@ -93,7 +95,7 @@ Changes
 
 
 3.0.0 (2004-11-07)
-------------------
+==================
 
 - Corresponds to the verison of the zope.tales package shipped as part of
   the Zope X3.0.0 release.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include tox.ini
 include bootstrap.py
 include buildout.cfg
+include .travis.yml
+include .coveragerc
 
 recursive-include src *
 

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,24 @@
-``zope.tales``
-==============
+================
+ ``zope.tales``
+================
+
+.. image:: https://img.shields.io/pypi/v/zope.tales.svg
+        :target: https://pypi.python.org/pypi/zope.tales/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.tales.svg
+        :target: https://pypi.org/project/zope.tales/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.tales.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.tales
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.tales/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.tales?branch=master
+
 Template Attribute Language - Expression Syntax
 
-See 
+See
 
 * http://web.archive.org/web/20120814103624/http://wiki.zope.org:80/ZPT/TALESSpecification13
 * https://docs.zope.org/zope2/zope2book/AppendixC.html#tales-overview

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -26,21 +26,10 @@ def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
 
-
-def alltests():
-    import os
-    import sys
-    import unittest
-    # use the zope.testrunner machinery to find all the
-    # test suites we've put under ourselves
-    import zope.testrunner.find
-    import zope.testrunner.options
-    here = os.path.abspath(os.path.join(os.path.dirname(__file__), 'src'))
-    args = sys.argv[:]
-    defaults = ["--test-path", here]
-    options = zope.testrunner.options.get_options(args, defaults)
-    suites = list(zope.testrunner.find.find_suites(options))
-    return unittest.TestSuite(suites)
+TESTS_REQUIRE = [
+    'zope.testing',
+    'zope.testrunner',
+]
 
 setup(name='zope.tales',
       version='4.2.0.dev0',
@@ -63,29 +52,32 @@ setup(name='zope.tales',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
           'Framework :: Zope3'],
-      url='http://pypi.python.org/pypi/zope.tales',
+      url='http://github.com/zopefoundation/zope.tales',
       license='ZPL 2.1',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       namespace_packages=['zope'],
-      extras_require=dict(
-          test=['zope.testing'],
-          tal=['zope.tal']),
+      extras_require={
+          'test': TESTS_REQUIRE,
+          'tal': [
+              'zope.tal',
+          ],
+      },
       install_requires=[
           'setuptools',
           'zope.interface',
-          'six'],
-      tests_require=['zope.testing', 'zope.testrunner'],
-      test_suite='__main__.alltests',
+          'six',
+      ],
+      tests_require=TESTS_REQUIRE,
       include_package_data=True,
       zip_safe=False,
-      )
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,31 +1,20 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3
+    py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
+    zope-testrunner --test-path=src []
 deps =
-    zope.interface
-    zope.testing
-    zope.testrunner
-
+    .[test]
 
 [testenv:coverage]
+usedevelop = true
 basepython =
     python2.7
 commands =
-#   The installed version messes up nose's test discovery / coverage reporting
-#   So, we uninstall that from the environment, and then install the editable
-#   version, before running nosetests.
-    pip uninstall -y zope.tales
-    pip install -e .
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report --fail-under=88
 deps =
-    nose
+    {[testenv]deps}
     coverage
-    nosexcover
-    zope.interface
-    zope.testing
-    zope.testrunner


### PR DESCRIPTION
Fixes #5 

The usual project gardening:

- Badges
- Use zope.testrunner for namespace path issue (drop setup.py test)
- Modern tox.ini/travis.yml
- Universal wheels
- Enable coverage environment and coveralls
  - Coverage is at 88%. There's a lot to do, I'll follow up with a
    separate PR. (See #6)