### PR TITLE
Point to pagetemplates.rtd.io instead of the zope2 book. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ independently). The two are integrated to produce page templates in
 `zope.pagetemplate <https://zopepagetemplate.readthedocs.io/>`_.
 
 The specification for TAL and TALES can be found at
-https://zope.readthedocs.io/en/latest/zope2book/AppendixC.html
+https://pagetemplates.readthedocs.io/en/latest/
 
 Documentation on this implementation and its API can be found at
 https://zopetales.readthedocs.io/


### PR DESCRIPTION
See zopefoundation/zope.tal#9