### PR TITLE
Cleanups for Plone 5.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@
 5.0.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Cleanups for Plone 5.2:
+  * in path alternatives, whitespace can now surround ``|``,
+  * non-ASCII in ``SubPathExpr`` now raises a ``CompilerError``
+    (instead of a ``UnicodeEncodeError``; to be compatible with
+    the ``chameleon`` template engine).
 
 
 5.0.1 (2019-06-26)

--- a/src/zope/tales/expressions.py
+++ b/src/zope/tales/expressions.py
@@ -67,7 +67,13 @@ class SubPathExpr(object):
         # Parse path
         compiledpath = []
         currentpath = []
-        for element in str(path).strip().split('/'):
+        try:
+           path = str(path)
+        except Exception as e:
+            raise engine.getCompilerError()(
+                'could not convert %r to `str`: %s: %s'
+                % (path, e.__class__.__name__, str(e)))
+        for element in path.strip().split('/'):
             if not element:
                 raise engine.getCompilerError()(
                     'Path element may not be empty in %r' % path)
@@ -242,7 +248,7 @@ class PathExpr(object):
 
 
 _interp = re.compile(
-    r'\$(%(n)s)|\${(%(n)s(?:/[^}|]*)*(?:\|%(n)s(?:/[^}|]*)*)*)}'
+    r'\$(%(n)s)|\${(%(n)s(?:/[^}|]*)*(?:\|\s*%(n)s(?:/[^}|]*)*)*)}'
     % {'n': NAME_RE})
 
 

--- a/src/zope/tales/tests/test_expressions.py
+++ b/src/zope/tales/tests/test_expressions.py
@@ -161,6 +161,20 @@ class TestParsedExpressions(ExpressionTestBase):
             expr = self.engine.compile('path:ErrorGenerator/%s|b|c/d/e' % e)
             self._check_evals_to(expr, 'boot')
 
+    def testOrPathWithSpaces(self):
+        expr = self.engine.compile('path:a | b | c/d/e')
+        self._check_evals_to(expr, 'boot')
+
+        for e in 'Undefined', 'AttributeError', 'LookupError', 'TypeError':
+            expr = self.engine.compile(
+                'path:ErrorGenerator/%s | b | c/d/e' % e)
+            self._check_evals_to(expr, 'boot')
+
+    def testNonAsciiPath(self):
+        error = self.engine.getCompilerError()
+        with self.assertRaises(error):
+            expr = self.engine.compile(u'path: ä')
+
     def test_path_CONTEXTS(self):
         self.context.contexts = 42
         self._check_evals_to('CONTEXTS', 42)


### PR DESCRIPTION
This PR fixes problems observed by Plone 5.2 tests and reported in
"https://github.com/zopefoundation/Zope/pull/807".

Specifically:

 * formerly whitespace was allowed in path alternatives before but not after the `|`; now whitespace is allowed before and after `|`.

 * `expressions.SubPathExpr` makes (under Python 2) the implicit assumption that its *path* parameter is ASCCI. Failure results in a `UnicodeEncodeError`. In order to obtain compatibility with the `chameleon` template engine, this exception is changed to `CompilerError`, i.e. the exception used to indicate a problem with the expression syntax.