### PR TITLE
Support (some) builtins in path expressions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 5.0.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Improve `PathExpr` reusability
+  Provide customizable support for the use of builtins in path expressions
 
 
 5.0.2 (2020-03-27)

--- a/src/zope/tales/expressions.py
+++ b/src/zope/tales/expressions.py
@@ -60,6 +60,8 @@ class SubPathExpr(object):
     Implementation of a single path expression.
     """
 
+    ALLOWED_BUILTINS = {}
+
     def __init__(self, path, traverser, engine):
         self._traverser = traverser
         self._engine = engine
@@ -137,7 +139,12 @@ class SubPathExpr(object):
         if base == 'CONTEXTS' or not base:  # Special base name
             ob = econtext.contexts
         else:
-            ob = vars[base]
+            try:
+                ob = vars[base]
+            except KeyError:
+                ob = self.ALLOWED_BUILTINS.get(base, _marker)
+                if ob is _marker:
+                    raise
         if isinstance(ob, DeferWrapper):
             ob = ob()
 
@@ -177,6 +184,8 @@ class PathExpr(object):
         'nocall',
     )
 
+    SUBEXPR_FACTORY = SubPathExpr
+
     def __init__(self, name, expr, engine, traverser=simpleTraverse):
         self._s = expr
         self._name = name
@@ -192,7 +201,7 @@ class PathExpr(object):
                 add(engine.compile('|'.join(paths[i:]).lstrip()))
                 self._hybrid = True
                 break
-            add(SubPathExpr(path, traverser, engine)._eval)
+            add(self.SUBEXPR_FACTORY(path, traverser, engine)._eval)
 
     def _exists(self, econtext):
         for expr in self._subexprs:

--- a/src/zope/tales/tests/test_expressions.py
+++ b/src/zope/tales/tests/test_expressions.py
@@ -392,7 +392,7 @@ class TestParsedExpressions(ExpressionTestBase):
         from ..expressions import PathExpr, SubPathExpr
 
         class MySubPathExpr(SubPathExpr):
-            ALLOWED_BUILTINS = {'True':True, 'False':False, 'x':None}
+            ALLOWED_BUILTINS = {'True': True, 'False': False, 'x': None}
 
         class MyPathExpr(PathExpr):
             SUBEXPR_FACTORY = MySubPathExpr

--- a/src/zope/tales/tests/test_expressions.py
+++ b/src/zope/tales/tests/test_expressions.py
@@ -387,6 +387,28 @@ class TestParsedExpressions(ExpressionTestBase):
             "Invalid variable name"
         )
 
+    def test_builtins_in_path(self):
+        from ..tales import ExpressionEngine
+        from ..expressions import PathExpr, SubPathExpr
+
+        class MySubPathExpr(SubPathExpr):
+            ALLOWED_BUILTINS = dict(True=True, False=False)
+
+        class MyPathExpr(PathExpr):
+            SUBEXPR_FACTORY = MySubPathExpr
+
+        engine = ExpressionEngine()
+        for pt in MyPathExpr._default_type_names:
+            engine.registerType(pt, MyPathExpr)
+
+        def eval(expr):
+            return engine.compile(expr)(self.context)
+
+        self.assertTrue(eval("True"))
+        self.assertFalse(eval("False"))
+        with self.assertRaises(KeyError):
+            eval("None")
+
 
 class FunctionTests(ExpressionTestBase):
 

--- a/src/zope/tales/tests/test_expressions.py
+++ b/src/zope/tales/tests/test_expressions.py
@@ -392,7 +392,7 @@ class TestParsedExpressions(ExpressionTestBase):
         from ..expressions import PathExpr, SubPathExpr
 
         class MySubPathExpr(SubPathExpr):
-            ALLOWED_BUILTINS = dict(True=True, False=False)
+            ALLOWED_BUILTINS = {'True':True, 'False':False, 'x':None}
 
         class MyPathExpr(PathExpr):
             SUBEXPR_FACTORY = MySubPathExpr
@@ -408,6 +408,7 @@ class TestParsedExpressions(ExpressionTestBase):
         self.assertFalse(eval("False"))
         with self.assertRaises(KeyError):
             eval("None")
+        self.assertIsNotNone(eval("x"))  # variable before builtin
 
 
 class FunctionTests(ExpressionTestBase):


### PR DESCRIPTION
``chameleon`` has become the most popular template engine in the Zope world. Its TALES implementation allows the use of builtins in its path expressions. E.g. one can use
`tal:omit="True"` instead of `tal:omit="python:True"`.

For consistency across the tales implementations used in the Zope world, it would be good when the path expressions of `zope.tales` would support builtins as well.

This PR slightly improves the reusability of `PathExpr` - allowing a deriving class to provide its own factory for subpaths.
It gives `SubPathExpr` a new class attribute `ALLOWED_BUILTINS` intended as a mapping for the supported builtins. `ALLOWED_BUILTINS` is consulted during the resolution of the initial component of a subpath when the lookup as a variable has failed.