### PR TITLE
Fix "Invalid variable name" error for base of path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Add support for Python 3.9, 3.10.
 
+- Fix error message raised if the first element of a path expression is not
+  a valid name.
+
 
 5.1 (2020-07-06)
 ================

--- a/src/zope/tales/expressions.py
+++ b/src/zope/tales/expressions.py
@@ -124,7 +124,7 @@ class SubPathExpr(object):
         base = first[0]
         if base and not _valid_name(base):
             raise engine.getCompilerError()(
-                'Invalid variable name "%s"' % element)
+                'Invalid variable name "%s"' % base)
         self._base = base
         compiledpath[0] = first[1:]
         self._compiled_path = tuple(compiledpath)

--- a/src/zope/tales/tests/test_expressions.py
+++ b/src/zope/tales/tests/test_expressions.py
@@ -193,8 +193,13 @@ class TestParsedExpressions(ExpressionTestBase):
 
     def test_dynamic_invalid_variable_name(self):
         from zope.tales.tales import CompilerError
-        with self.assertRaisesRegex(CompilerError, "Invalid variable name"):
+        with self.assertRaisesRegex(
+                CompilerError, 'Invalid variable name "123"'):
             self.engine.compile('path:a/?123')
+        # Deliberate typo for the TAL construct "structure ...".
+        with self.assertRaisesRegex(
+                CompilerError, 'Invalid variable name "structured a"'):
+            self.engine.compile('structured a/b')
 
     def testOldStyleClassIsCalled(self):
         class AnOldStyleClass:


### PR DESCRIPTION
If you were aiming for this TAL fragment:

    <p class="error message"
       tal:condition="view/error_message"
       tal:content="structure view/error_message/escapedtext" />

... but instead mistype it as this:

    <p class="error message"
       tal:condition="view/error_message"
       tal:content="structured view/error_message/escapedtext" />

... then you get this very confusing exception:

    zope.tal.taldefs.TALError: Invalid variable name "escapedtext" in
    expression 'structured view/error_message/escapedtext', at ...

But "escapedtext" is not the invalid name here; it's "structured view",
because the typo of "structured" for "structure" means that `zope.tal`
doesn't interpret that part of the attribute before passing it on to
`zope.tales` to evaluate the path expression.  Fix the incorrect error
message.